### PR TITLE
Crash Bug Fix

### DIFF
--- a/agent/go.mod
+++ b/agent/go.mod
@@ -4,7 +4,7 @@ go 1.23
 
 require (
 	github.com/shirou/gopsutil/v3 v3.24.1
-	github.com/zarkones/xena-client v0.3.3
+	github.com/zarkones/xena-client v0.3.4
 	github.com/zarkones/xena-crypto v0.0.2
 )
 

--- a/agent/go.sum
+++ b/agent/go.sum
@@ -34,8 +34,8 @@ github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+F
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
 github.com/yusufpapurcu/wmi v1.2.3 h1:E1ctvB7uKFMOJw3fdOW32DwGE9I7t++CRUEMKvFoFiw=
 github.com/yusufpapurcu/wmi v1.2.3/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-github.com/zarkones/xena-client v0.3.3 h1:dj8a/CLJfAIkCfrcb17q35/+8RwvECf6ZdIHnxkpcys=
-github.com/zarkones/xena-client v0.3.3/go.mod h1:9vKKA56Hevr7n4zPPtTV0C3zb6cFsN3nkh9fSYAO0G0=
+github.com/zarkones/xena-client v0.3.4 h1:nKWihuNm5wmvVEoH5nPBCYiJIDNR1bsErIxRXEJLEKk=
+github.com/zarkones/xena-client v0.3.4/go.mod h1:9vKKA56Hevr7n4zPPtTV0C3zb6cFsN3nkh9fSYAO0G0=
 github.com/zarkones/xena-crypto v0.0.2 h1:C6wNT5fLcZPG5VSECiKeMN2djdQbqalsRuad10XYWLw=
 github.com/zarkones/xena-crypto v0.0.2/go.mod h1:e8cSGbd+uBgkf0gm4ktF/Jh9NmPca6NaL5Ta8de4+eg=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/c2/go.mod
+++ b/c2/go.mod
@@ -4,7 +4,7 @@ go 1.23
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/zarkones/xena-client v0.3.3
+	github.com/zarkones/xena-client v0.3.4
 	github.com/zarkones/xena-crypto v0.0.2
 	gorm.io/gorm v1.25.5
 )

--- a/c2/go.sum
+++ b/c2/go.sum
@@ -94,8 +94,8 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
-github.com/zarkones/xena-client v0.3.3 h1:dj8a/CLJfAIkCfrcb17q35/+8RwvECf6ZdIHnxkpcys=
-github.com/zarkones/xena-client v0.3.3/go.mod h1:9vKKA56Hevr7n4zPPtTV0C3zb6cFsN3nkh9fSYAO0G0=
+github.com/zarkones/xena-client v0.3.4 h1:nKWihuNm5wmvVEoH5nPBCYiJIDNR1bsErIxRXEJLEKk=
+github.com/zarkones/xena-client v0.3.4/go.mod h1:9vKKA56Hevr7n4zPPtTV0C3zb6cFsN3nkh9fSYAO0G0=
 github.com/zarkones/xena-crypto v0.0.2 h1:C6wNT5fLcZPG5VSECiKeMN2djdQbqalsRuad10XYWLw=
 github.com/zarkones/xena-crypto v0.0.2/go.mod h1:e8cSGbd+uBgkf0gm4ktF/Jh9NmPca6NaL5Ta8de4+eg=
 golang.org/x/arch v0.0.0-20210923205945-b76863e36670/go.mod h1:5om86z9Hs0C8fWVUuoMHwpExlXzs5Tkyp9hOrfG7pp8=

--- a/common/builder/builder.go
+++ b/common/builder/builder.go
@@ -33,9 +33,20 @@ func BuildAgent(w fyne.Window) fyne.CanvasObject {
 
 	pubKeyPEM, err := xenaC2.GetC2PublicKey()
 	if err != nil {
+		if errors.Is(err, xenaC2.ErrNilAuthToken) {
+			return container.NewScroll(container.NewVBox(
+				widget.NewLabel("API key for C2 server is not set or is invalid, go to 'Settings' page and set it."),
+			))
+		}
 		return container.NewScroll(container.NewVBox(
 			widget.NewLabel("Failed to Get Public Key of the C2"),
 			widget.NewLabel(err.Error()),
+		))
+	}
+
+	if len(pubKeyPEM) == 0 {
+		return container.NewScroll(container.NewVBox(
+			widget.NewLabel("Received no key from the C2 server. C2 API key might be invalid, leading to C2 refusing to serve us its public key."),
 		))
 	}
 

--- a/common/go.mod
+++ b/common/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gin-gonic/gin v1.9.1
 	github.com/jackpal/gateway v1.0.7
 	github.com/mitchellh/go-ps v1.0.0
-	github.com/zarkones/xena-client v0.3.3
+	github.com/zarkones/xena-client v0.3.4
 	github.com/zarkones/xena-crypto v0.0.2
 	golang.org/x/crypto v0.20.0
 	golang.org/x/sys v0.17.0

--- a/common/go.sum
+++ b/common/go.sum
@@ -311,8 +311,8 @@ github.com/yuin/goldmark v1.4.0/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yuin/goldmark v1.5.5 h1:IJznPe8wOzfIKETmMkd06F8nXkmlhaHqFRM9l1hAGsU=
 github.com/yuin/goldmark v1.5.5/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-github.com/zarkones/xena-client v0.3.3 h1:dj8a/CLJfAIkCfrcb17q35/+8RwvECf6ZdIHnxkpcys=
-github.com/zarkones/xena-client v0.3.3/go.mod h1:9vKKA56Hevr7n4zPPtTV0C3zb6cFsN3nkh9fSYAO0G0=
+github.com/zarkones/xena-client v0.3.4 h1:nKWihuNm5wmvVEoH5nPBCYiJIDNR1bsErIxRXEJLEKk=
+github.com/zarkones/xena-client v0.3.4/go.mod h1:9vKKA56Hevr7n4zPPtTV0C3zb6cFsN3nkh9fSYAO0G0=
 github.com/zarkones/xena-crypto v0.0.2 h1:C6wNT5fLcZPG5VSECiKeMN2djdQbqalsRuad10XYWLw=
 github.com/zarkones/xena-crypto v0.0.2/go.mod h1:e8cSGbd+uBgkf0gm4ktF/Jh9NmPca6NaL5Ta8de4+eg=
 go.etcd.io/etcd/api/v3 v3.5.0/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=

--- a/go.work.sum
+++ b/go.work.sum
@@ -19,7 +19,6 @@ github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbV
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/gofrs/flock v0.8.0/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
-github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/pprof v0.0.0-20211214055906-6f57359322fd/go.mod h1:KgnwoLYCZ8IQu3XUZ8Nc/bM9CCZFOyjUNOSygVozoDg=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/hajimehoshi/bitmapfont v1.3.0/go.mod h1:/Qb7yVjHYNUV4JdqNkPs6BSZwLjKqkZOMIp6jZD0KgE=
@@ -55,6 +54,8 @@ github.com/urfave/cli/v2 v2.4.0 h1:m2pxjjDFgDxSPtO8WSdbndj17Wu2y8vOT86wE/tjr+I=
 github.com/wagslane/go-password-validator v0.3.0 h1:vfxOPzGHkz5S146HDpavl0cw1DSVP061Ry2PX0/ON6I=
 github.com/zarkones/xena-client v0.3.2 h1:o19/zwV/z83IAtMl50t/y7A3xac4Hc9m2lliVDkysbo=
 github.com/zarkones/xena-client v0.3.2/go.mod h1:9vKKA56Hevr7n4zPPtTV0C3zb6cFsN3nkh9fSYAO0G0=
+github.com/zarkones/xena-client v0.3.4 h1:nKWihuNm5wmvVEoH5nPBCYiJIDNR1bsErIxRXEJLEKk=
+github.com/zarkones/xena-client v0.3.4/go.mod h1:9vKKA56Hevr7n4zPPtTV0C3zb6cFsN3nkh9fSYAO0G0=
 golang.org/x/crypto v0.7.0/go.mod h1:pYwdfH91IfpZVANVyUOhSIPZaFoJGxTFbZhFTx+dXZU=
 golang.org/x/crypto v0.13.0 h1:mvySKfSWJ+UKUii46M40LOvyWfN0s2U+46/jDd0e6Ck=
 golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliYc=

--- a/modules/offsec/go.mod
+++ b/modules/offsec/go.mod
@@ -4,7 +4,7 @@ go 1.23
 
 require (
 	github.com/gocolly/colly v1.2.0
-	github.com/zarkones/xena-client v0.3.3
+	github.com/zarkones/xena-client v0.3.4
 	golang.org/x/exp v0.0.0-20240222234643-814bf88cf225
 )
 

--- a/modules/offsec/go.sum
+++ b/modules/offsec/go.sum
@@ -39,8 +39,8 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/temoto/robotstxt v1.1.2 h1:W2pOjSJ6SWvldyEuiFXNxz3xZ8aiWX5LbfDiOFd7Fxg=
 github.com/temoto/robotstxt v1.1.2/go.mod h1:+1AmkuG3IYkh1kv0d2qEB9Le88ehNO0zwOr3ujewlOo=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-github.com/zarkones/xena-client v0.3.3 h1:dj8a/CLJfAIkCfrcb17q35/+8RwvECf6ZdIHnxkpcys=
-github.com/zarkones/xena-client v0.3.3/go.mod h1:9vKKA56Hevr7n4zPPtTV0C3zb6cFsN3nkh9fSYAO0G0=
+github.com/zarkones/xena-client v0.3.4 h1:nKWihuNm5wmvVEoH5nPBCYiJIDNR1bsErIxRXEJLEKk=
+github.com/zarkones/xena-client v0.3.4/go.mod h1:9vKKA56Hevr7n4zPPtTV0C3zb6cFsN3nkh9fSYAO0G0=
 github.com/zarkones/xena-crypto v0.0.2 h1:C6wNT5fLcZPG5VSECiKeMN2djdQbqalsRuad10XYWLw=
 github.com/zarkones/xena-crypto v0.0.2/go.mod h1:e8cSGbd+uBgkf0gm4ktF/Jh9NmPca6NaL5Ta8de4+eg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -4,7 +4,7 @@ go 1.23
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/zarkones/xena-client v0.3.3
+	github.com/zarkones/xena-client v0.3.4
 	github.com/zarkones/xena-crypto v0.0.2
 )
 

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -8,8 +8,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/zarkones/xena-client v0.3.3 h1:dj8a/CLJfAIkCfrcb17q35/+8RwvECf6ZdIHnxkpcys=
-github.com/zarkones/xena-client v0.3.3/go.mod h1:9vKKA56Hevr7n4zPPtTV0C3zb6cFsN3nkh9fSYAO0G0=
+github.com/zarkones/xena-client v0.3.4 h1:nKWihuNm5wmvVEoH5nPBCYiJIDNR1bsErIxRXEJLEKk=
+github.com/zarkones/xena-client v0.3.4/go.mod h1:9vKKA56Hevr7n4zPPtTV0C3zb6cFsN3nkh9fSYAO0G0=
 github.com/zarkones/xena-crypto v0.0.2 h1:C6wNT5fLcZPG5VSECiKeMN2djdQbqalsRuad10XYWLw=
 github.com/zarkones/xena-crypto v0.0.2/go.mod h1:e8cSGbd+uBgkf0gm4ktF/Jh9NmPca6NaL5Ta8de4+eg=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/ui/go.mod
+++ b/ui/go.mod
@@ -5,7 +5,7 @@ go 1.23
 require (
 	fyne.io/fyne/v2 v2.4.4
 	github.com/google/uuid v1.6.0
-	github.com/zarkones/xena-client v0.3.1
+	github.com/zarkones/xena-client v0.3.4
 	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a
 )
 

--- a/ui/go.sum
+++ b/ui/go.sum
@@ -318,8 +318,8 @@ github.com/yuin/goldmark v1.4.0/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yuin/goldmark v1.5.5 h1:IJznPe8wOzfIKETmMkd06F8nXkmlhaHqFRM9l1hAGsU=
 github.com/yuin/goldmark v1.5.5/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-github.com/zarkones/xena-client v0.3.1 h1:8DukfiTp1/cbq2kqSISI2YxN5s9teZglSHKvDj86530=
-github.com/zarkones/xena-client v0.3.1/go.mod h1:9vKKA56Hevr7n4zPPtTV0C3zb6cFsN3nkh9fSYAO0G0=
+github.com/zarkones/xena-client v0.3.4 h1:nKWihuNm5wmvVEoH5nPBCYiJIDNR1bsErIxRXEJLEKk=
+github.com/zarkones/xena-client v0.3.4/go.mod h1:9vKKA56Hevr7n4zPPtTV0C3zb6cFsN3nkh9fSYAO0G0=
 github.com/zarkones/xena-crypto v0.0.2 h1:C6wNT5fLcZPG5VSECiKeMN2djdQbqalsRuad10XYWLw=
 github.com/zarkones/xena-crypto v0.0.2/go.mod h1:e8cSGbd+uBgkf0gm4ktF/Jh9NmPca6NaL5Ta8de4+eg=
 go.etcd.io/etcd/api/v3 v3.5.0/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=


### PR DESCRIPTION
If you had no C2 API key or a wrong key set in the Settings of the UI client it might crash when you try to build an agent.

Reason for that is; C2 wouldn't return its public key, and we'd try to pem decode a slice of bytes of length zero. Tale as old as programming itself I suppose.

A change was required in xena-client which now sits at 0.3.4, and in one file in XENA itself.